### PR TITLE
Added: View for shipment order Items (#1)

### DIFF
--- a/entity/OmsOrderViewEntities.xml
+++ b/entity/OmsOrderViewEntities.xml
@@ -351,13 +351,13 @@ under the License.
         <alias entity-alias="OH" name="grandTotal"/>
         <alias entity-alias="OI" name="orderItemSeqId"/>
         <alias entity-alias="OI" field="statusId" name="itemStatusId"/>
-        <alias entity-alias="OI" field="quantity" name="itemQuantity"/>
         <alias entity-alias="OI" name="unitPrice"/>
         <alias entity-alias="OI" field="externalId" name="orderItemExternalId"/>
         <alias entity-alias="OISG" name="shipGroupSeqId"/>
         <alias entity-alias="OISG" field="shipmentMethodTypeId" name="slaShipmentMethodTypeId"/>
         <alias entity-alias="OISG" field="contactMechId" name="postalContactMechId"/>
         <alias entity-alias="OISG" name="telecomContactMechId"/>
+        <alias entity-alias="OISGA" field="quantity" name="itemQuantity"/>
         <alias entity-alias="EFO" name="externalFulfillmentOrderItemId"/>
         <alias entity-alias="EFO" name="fulfillmentStatus"/>
         <alias entity-alias="P" field="firstName" name="customerFirstName"/>

--- a/entity/OmsOrderViewEntities.xml
+++ b/entity/OmsOrderViewEntities.xml
@@ -277,6 +277,104 @@ under the License.
         </entity-condition>
     </view-entity>
 
+    <view-entity entity-name="ShipmentOrderItemsSyncQueue" package="co.hotwax.warehouse" group="ofbiz_transactional">
+        <description>View to get details for the Shipment Order Items.</description>
+        <member-entity entity-alias="SH" entity-name="org.apache.ofbiz.shipment.shipment.Shipment"/>
+        <member-entity entity-alias="SHI" entity-name="org.apache.ofbiz.shipment.shipment.ShipmentItem" join-from-alias="SH">
+            <key-map field-name="shipmentId"/>
+        </member-entity>
+        <member-entity entity-alias="OSH" entity-name="org.apache.ofbiz.order.order.OrderShipment" join-from-alias="SHI">
+            <key-map field-name="shipmentId"/>
+            <key-map field-name="shipmentItemSeqId"/>
+        </member-entity>
+        <member-entity entity-alias="OISGA" entity-name="org.apache.ofbiz.order.order.OrderItemShipGroupAssoc" join-from-alias="OSH">
+            <key-map field-name="orderId"/>
+            <key-map field-name="orderItemSeqId"/>
+            <key-map field-name="shipGroupSeqId"/>
+        </member-entity>
+        <member-entity entity-alias="OH" entity-name="org.apache.ofbiz.order.order.OrderHeader" join-from-alias="SH" join-optional="true">
+            <key-map field-name="primaryOrderId"/>
+        </member-entity>
+        <member-entity entity-alias="EFO" entity-name="co.hotwax.warehouse.ExternalFulfillmentOrderItem" join-from-alias="OSH" join-optional="true">
+            <key-map field-name="orderId"/>
+            <key-map field-name="orderItemSeqId"/>
+            <key-map field-name="shipGroupSeqId"/>
+        </member-entity>
+        <member-entity entity-alias="SCENM" entity-name="org.apache.ofbiz.common.enum.Enumeration" join-from-alias="OH" join-optional="true">
+            <key-map field-name="salesChannelEnumId" related="enumId"/>
+        </member-entity>
+        <member-entity entity-alias="OI" entity-name="org.apache.ofbiz.order.order.OrderItem" join-from-alias="OSH" join-optional="true">
+            <key-map field-name="orderId"/>
+            <key-map field-name="orderItemSeqId"/>
+        </member-entity>
+        <member-entity entity-alias="OS" entity-name="org.apache.ofbiz.order.order.OrderStatus" join-from-alias="OI" join-optional="true">
+            <key-map field-name="orderId"/>
+            <key-map field-name="orderItemSeqId"/>
+            <key-map field-name="statusId"/>
+        </member-entity>
+        <member-entity entity-alias="F" entity-name="org.apache.ofbiz.product.facility.Facility" join-from-alias="SH">
+            <key-map field-name="originFacilityId"/>
+        </member-entity>
+        <member-entity entity-alias="FT" entity-name="org.apache.ofbiz.product.facility.FacilityType" join-from-alias="F">
+            <key-map field-name="facilityTypeId"/>
+        </member-entity>
+        <member-entity entity-alias="ODR" entity-name="org.apache.ofbiz.order.order.OrderRole" join-from-alias="OSH" join-optional="true">
+            <key-map field-name="orderId"/>
+        </member-entity>
+        <member-entity entity-alias="P" entity-name="org.apache.ofbiz.party.party.Person" join-from-alias="ODR" join-optional="true">
+            <key-map field-name="partyId"/>
+        </member-entity>
+        <member-entity entity-alias="PD" entity-name="org.apache.ofbiz.product.product.Product" join-from-alias="OI" join-optional="true">
+            <key-map field-name="productId"/>
+        </member-entity>
+        <member-entity entity-alias="UOM" entity-name="org.apache.ofbiz.common.uom.Uom" join-from-alias="OH" join-optional="true">
+            <key-map field-name="currencyUom" related="uomId"/>
+        </member-entity>
+        <alias entity-alias="OH" name="productStoreId"/>
+        <alias entity-alias="OH" name="orderId"/>
+        <alias entity-alias="OH" name="orderName"/>
+        <alias entity-alias="OH" name="orderDate"/>
+        <alias entity-alias="OH" field="statusId" name="orderStatusId"/>
+        <alias entity-alias="OH" name="entryDate"/>
+        <alias entity-alias="OH" name="grandTotal"/>
+        <alias entity-alias="OI" name="orderItemSeqId"/>
+        <alias entity-alias="OI" field="statusId" name="itemStatusId"/>
+        <alias entity-alias="OI" name="unitPrice"/>
+        <alias entity-alias="OI" field="externalId" name="orderItemExternalId"/>
+        <alias entity-alias="UOM" field="abbreviation" name="currency"/>
+        <alias entity-alias="SH" field="statusId" name="shipmentStatusId"/>
+        <alias entity-alias="SH" field="destinationContactMechId" name="shipToContactMechId"/>
+        <alias entity-alias="SH" field="destinationTelecomNumberId" name="shipToTelecomContactMechId"/>
+        <alias entity-alias="SH" name="shipmentMethodTypeId"/>
+        <alias entity-alias="SH" field="primaryShipGroupSeqId" name="shipmentShipGroupSeqId"/>
+        <alias entity-alias="SH" name="shipmentId"/>
+        <alias entity-alias="SHI" name="quantity"/>
+        <alias entity-alias="SHI" name="shipmentItemSeqId"/>
+        <alias entity-alias="EFO" name="externalFulfillmentOrderItemId"/>
+        <alias entity-alias="EFO" name="fulfillmentStatus"/>
+        <alias entity-alias="P" field="firstName" name="customerFirstName"/>
+        <alias entity-alias="P" field="lastName" name="customerLastName"/>
+        <alias entity-alias="F" name="facilityId"/>
+        <alias entity-alias="F" field="externalId" name="facilityExternalId" />
+        <alias entity-alias="FT" name="facilityTypeId"/>
+        <alias entity-alias="FT" field="parentTypeId" name="parentFacilityTypeId"/>
+        <alias entity-alias="OS" name="statusDatetime"/>
+        <alias entity-alias="PD" name="productId"/>
+        <alias entity-alias="SCENM" field="enumCode" name="salesChannel"/>
+        <alias entity-alias="ODR" field="partyId" name="customerPartyId"/>
+        <entity-condition>
+            <econditions combine="and">
+                <econdition entity-alias="OH" field-name="orderTypeId" operator="equals" value="SALES_ORDER"/>
+                <econditions combine="or">
+                    <econdition entity-alias="EFO" field-name="fulfillmentStatus" operator="equals" value="REJECT"/>
+                    <econdition entity-alias="EFO" field-name="fulfillmentStatus" operator="equals" value=""/>
+                </econditions>
+                <econdition entity-alias="ODR" field-name="roleTypeId" operator="equals" value="BILL_TO_CUSTOMER"/>
+            </econditions>
+            <order-by field-name="entryDate"/>
+        </entity-condition>
+    </view-entity>
+
     <view-entity entity-name="PostalAddressView" package="co.hotwax.financial" group="ofbiz_transactional">
         <member-entity entity-alias="PA" entity-name="org.apache.ofbiz.party.contact.PostalAddress"/>
         <member-entity entity-alias="COUNTRYGEO" entity-name="org.apache.ofbiz.common.geo.Geo" join-from-alias="PA" join-optional="true">

--- a/entity/OmsOrderViewEntities.xml
+++ b/entity/OmsOrderViewEntities.xml
@@ -277,104 +277,6 @@ under the License.
         </entity-condition>
     </view-entity>
 
-    <view-entity entity-name="ShipmentOrderItemsSyncQueue" package="co.hotwax.warehouse" group="ofbiz_transactional">
-        <description>View to get details for the Shipment Order Items.</description>
-        <member-entity entity-alias="SH" entity-name="org.apache.ofbiz.shipment.shipment.Shipment"/>
-        <member-entity entity-alias="SHI" entity-name="org.apache.ofbiz.shipment.shipment.ShipmentItem" join-from-alias="SH">
-            <key-map field-name="shipmentId"/>
-        </member-entity>
-        <member-entity entity-alias="OSH" entity-name="org.apache.ofbiz.order.order.OrderShipment" join-from-alias="SHI">
-            <key-map field-name="shipmentId"/>
-            <key-map field-name="shipmentItemSeqId"/>
-        </member-entity>
-        <member-entity entity-alias="OISGA" entity-name="org.apache.ofbiz.order.order.OrderItemShipGroupAssoc" join-from-alias="OSH">
-            <key-map field-name="orderId"/>
-            <key-map field-name="orderItemSeqId"/>
-            <key-map field-name="shipGroupSeqId"/>
-        </member-entity>
-        <member-entity entity-alias="OH" entity-name="org.apache.ofbiz.order.order.OrderHeader" join-from-alias="SH" join-optional="true">
-            <key-map field-name="primaryOrderId"/>
-        </member-entity>
-        <member-entity entity-alias="EFO" entity-name="co.hotwax.warehouse.ExternalFulfillmentOrderItem" join-from-alias="OSH" join-optional="true">
-            <key-map field-name="orderId"/>
-            <key-map field-name="orderItemSeqId"/>
-            <key-map field-name="shipGroupSeqId"/>
-        </member-entity>
-        <member-entity entity-alias="SCENM" entity-name="org.apache.ofbiz.common.enum.Enumeration" join-from-alias="OH" join-optional="true">
-            <key-map field-name="salesChannelEnumId" related="enumId"/>
-        </member-entity>
-        <member-entity entity-alias="OI" entity-name="org.apache.ofbiz.order.order.OrderItem" join-from-alias="OSH" join-optional="true">
-            <key-map field-name="orderId"/>
-            <key-map field-name="orderItemSeqId"/>
-        </member-entity>
-        <member-entity entity-alias="OS" entity-name="org.apache.ofbiz.order.order.OrderStatus" join-from-alias="OI" join-optional="true">
-            <key-map field-name="orderId"/>
-            <key-map field-name="orderItemSeqId"/>
-            <key-map field-name="statusId"/>
-        </member-entity>
-        <member-entity entity-alias="F" entity-name="org.apache.ofbiz.product.facility.Facility" join-from-alias="SH">
-            <key-map field-name="originFacilityId"/>
-        </member-entity>
-        <member-entity entity-alias="FT" entity-name="org.apache.ofbiz.product.facility.FacilityType" join-from-alias="F">
-            <key-map field-name="facilityTypeId"/>
-        </member-entity>
-        <member-entity entity-alias="ODR" entity-name="org.apache.ofbiz.order.order.OrderRole" join-from-alias="OSH" join-optional="true">
-            <key-map field-name="orderId"/>
-        </member-entity>
-        <member-entity entity-alias="P" entity-name="org.apache.ofbiz.party.party.Person" join-from-alias="ODR" join-optional="true">
-            <key-map field-name="partyId"/>
-        </member-entity>
-        <member-entity entity-alias="PD" entity-name="org.apache.ofbiz.product.product.Product" join-from-alias="OI" join-optional="true">
-            <key-map field-name="productId"/>
-        </member-entity>
-        <member-entity entity-alias="UOM" entity-name="org.apache.ofbiz.common.uom.Uom" join-from-alias="OH" join-optional="true">
-            <key-map field-name="currencyUom" related="uomId"/>
-        </member-entity>
-        <alias entity-alias="OH" name="productStoreId"/>
-        <alias entity-alias="OH" name="orderId"/>
-        <alias entity-alias="OH" name="orderName"/>
-        <alias entity-alias="OH" name="orderDate"/>
-        <alias entity-alias="OH" field="statusId" name="orderStatusId"/>
-        <alias entity-alias="OH" name="entryDate"/>
-        <alias entity-alias="OH" name="grandTotal"/>
-        <alias entity-alias="OI" name="orderItemSeqId"/>
-        <alias entity-alias="OI" field="statusId" name="itemStatusId"/>
-        <alias entity-alias="OI" name="unitPrice"/>
-        <alias entity-alias="OI" field="externalId" name="orderItemExternalId"/>
-        <alias entity-alias="UOM" field="abbreviation" name="currency"/>
-        <alias entity-alias="SH" field="statusId" name="shipmentStatusId"/>
-        <alias entity-alias="SH" field="destinationContactMechId" name="shipToContactMechId"/>
-        <alias entity-alias="SH" field="destinationTelecomNumberId" name="shipToTelecomContactMechId"/>
-        <alias entity-alias="SH" name="shipmentMethodTypeId"/>
-        <alias entity-alias="SH" field="primaryShipGroupSeqId" name="shipmentShipGroupSeqId"/>
-        <alias entity-alias="SH" name="shipmentId"/>
-        <alias entity-alias="SHI" name="quantity"/>
-        <alias entity-alias="SHI" name="shipmentItemSeqId"/>
-        <alias entity-alias="EFO" name="externalFulfillmentOrderItemId"/>
-        <alias entity-alias="EFO" name="fulfillmentStatus"/>
-        <alias entity-alias="P" field="firstName" name="customerFirstName"/>
-        <alias entity-alias="P" field="lastName" name="customerLastName"/>
-        <alias entity-alias="F" name="facilityId"/>
-        <alias entity-alias="F" field="externalId" name="facilityExternalId" />
-        <alias entity-alias="FT" name="facilityTypeId"/>
-        <alias entity-alias="FT" field="parentTypeId" name="parentFacilityTypeId"/>
-        <alias entity-alias="OS" name="statusDatetime"/>
-        <alias entity-alias="PD" name="productId"/>
-        <alias entity-alias="SCENM" field="enumCode" name="salesChannel"/>
-        <alias entity-alias="ODR" field="partyId" name="customerPartyId"/>
-        <entity-condition>
-            <econditions combine="and">
-                <econdition entity-alias="OH" field-name="orderTypeId" operator="equals" value="SALES_ORDER"/>
-                <econditions combine="or">
-                    <econdition entity-alias="EFO" field-name="fulfillmentStatus" operator="equals" value="REJECT"/>
-                    <econdition entity-alias="EFO" field-name="fulfillmentStatus" operator="equals" value=""/>
-                </econditions>
-                <econdition entity-alias="ODR" field-name="roleTypeId" operator="equals" value="BILL_TO_CUSTOMER"/>
-            </econditions>
-            <order-by field-name="entryDate"/>
-        </entity-condition>
-    </view-entity>
-
     <!-- View entity to fetch the Order Items for FulfilledOrder Reporting, using member entities of OFBiz -->
     <view-entity entity-name="FulfilledOrderItemsSyncQueue" package="co.hotwax.warehouse" group="ofbiz_transactional">
         <description>View to get details for the Brokered Order Items.</description>
@@ -388,28 +290,23 @@ under the License.
         <member-entity entity-alias="OISGA" entity-name="org.apache.ofbiz.order.order.OrderItemShipGroupAssoc" join-from-alias="OI">
             <key-map field-name="orderId"/>
             <key-map field-name="orderItemSeqId"/>
-<!--            <key-map field-name="shipGroupSeqId"/>-->
         </member-entity>
         <member-entity entity-alias="OISG" entity-name="org.apache.ofbiz.order.order.OrderItemShipGroup" join-from-alias="OISGA">
             <key-map field-name="orderId"/>
             <key-map field-name="shipGroupSeqId"/>
         </member-entity>
-<!--        <member-entity entity-alias="OSH" entity-name="org.apache.ofbiz.order.order.OrderShipment" join-from-alias="OISGA" join-optional="true">-->
-<!--            <key-map field-name="orderId"/>-->
-<!--            <key-map field-name="orderItemSeqId"/>-->
-<!--            <key-map field-name="shipGroupSeqId"/>-->
-<!--        </member-entity>-->
-        <member-entity entity-alias="SH" entity-name="org.apache.ofbiz.shipment.shipment.Shipment" join-from-alias="OISG" join-optional="true">
-        <key-map field-name="orderId" related="primaryOrderId"/>
-        <key-map field-name="shipGroupSeqId" related="primaryShipGroupSeqId"/>
+        <member-entity entity-alias="OSH" entity-name="org.apache.ofbiz.order.order.OrderShipment" join-from-alias="OISGA" join-optional="true">
+            <key-map field-name="orderId"/>
+            <key-map field-name="orderItemSeqId"/>
+            <key-map field-name="shipGroupSeqId"/>
         </member-entity>
-<!--        <member-entity entity-alias="SH" entity-name="org.apache.ofbiz.shipment.shipment.Shipment" join-from-alias="OSH" join-optional="false">-->
-<!--        <key-map field-name="shipmentId"/>-->
-<!--        <key-map field-name="shipGroupSeqId" related="primaryShipGroupSeqId"/>-->
-<!--        </member-entity>-->
-<!--        <member-entity entity-alias="SHI" entity-name="org.apache.ofbiz.shipment.shipment.ShipmentItem" join-from-alias="SH">-->
-<!--            <key-map field-name="shipmentId"/>-->
-<!--        </member-entity>-->
+        <member-entity entity-alias="SHI" entity-name="org.apache.ofbiz.shipment.shipment.ShipmentItem" join-from-alias="OSH" join-optional="true">
+            <key-map field-name="shipmentId"/>
+            <key-map field-name="shipmentItemSeqId"/>
+        </member-entity>
+        <member-entity entity-alias="SH" entity-name="org.apache.ofbiz.shipment.shipment.Shipment" join-from-alias="SHI" join-optional="true">
+            <key-map field-name="shipmentId"/>
+        </member-entity>
         <member-entity entity-alias="EFO" entity-name="co.hotwax.warehouse.ExternalFulfillmentOrderItem" join-from-alias="OISGA" join-optional="true">
             <key-map field-name="orderId"/>
             <key-map field-name="orderItemSeqId"/>
@@ -432,15 +329,20 @@ under the License.
         <member-entity entity-alias="P" entity-name="org.apache.ofbiz.party.party.Person" join-from-alias="ODR" join-optional="true">
             <key-map field-name="partyId"/>
         </member-entity>
-        <member-entity entity-alias="PD" entity-name="org.apache.ofbiz.product.product.Product" join-from-alias="OI">
+        <member-entity entity-alias="PD" entity-name="org.apache.ofbiz.product.product.Product" join-from-alias="OI" join-optional="true">
             <key-map field-name="productId"/>
+        </member-entity>
+        <member-entity entity-alias="PT" entity-name="org.apache.ofbiz.product.product.ProductType" join-from-alias="PD" join-optional="true">
+            <key-map field-name="productTypeId"/>
         </member-entity>
         <member-entity entity-alias="UOM" entity-name="org.apache.ofbiz.common.uom.Uom" join-from-alias="OH">
             <key-map field-name="currencyUom" related="uomId"/>
         </member-entity>
+        <member-entity entity-alias="SHIRS" entity-name="org.apache.ofbiz.shipment.shipment.ShipmentRouteSegment" join-from-alias="SH" join-optional="true">
+            <key-map field-name="shipmentId"/>
+        </member-entity>
         <alias entity-alias="OH" name="productStoreId"/>
         <alias entity-alias="OH" name="orderId"/>
-<!--        <alias entity-alias="SH" name="primaryOrderId"/>-->
         <alias entity-alias="OH" name="orderName"/>
         <alias entity-alias="OH" name="orderDate"/>
         <alias entity-alias="OH" field="statusId" name="orderStatusId"/>
@@ -449,19 +351,13 @@ under the License.
         <alias entity-alias="OH" name="grandTotal"/>
         <alias entity-alias="OI" name="orderItemSeqId"/>
         <alias entity-alias="OI" field="statusId" name="itemStatusId"/>
-        <alias entity-alias="OISGA" name="quantity"/>
-<!--        <alias entity-alias="OISGA" field="quantity" name="oiqqqqq"/>-->
+        <alias entity-alias="OI" field="quantity" name="itemQuantity"/>
         <alias entity-alias="OI" name="unitPrice"/>
-        <alias entity-alias="PD" name="productTypeId"/>
         <alias entity-alias="OI" field="externalId" name="orderItemExternalId"/>
-        <alias entity-alias="SH" field="statusId" name="shipmentStatusId"/>
-        <alias entity-alias="SH" field="destinationContactMechId" name="shipToContactMechId"/>
-        <alias entity-alias="SH" field="destinationTelecomNumberId" name="shipToTelecomContactMechId"/>
-        <alias entity-alias="SH" name="shipmentMethodTypeId"/>
-        <alias entity-alias="OISG"  name="shipGroupSeqId"/>
-        <alias entity-alias="SH" name="shipmentId"/>
-<!--        <alias entity-alias="OSH" name="quantity"/>-->
-<!--        <alias entity-alias="OSH" name="shipmentItemSeqId"/>-->
+        <alias entity-alias="OISG" name="shipGroupSeqId"/>
+        <alias entity-alias="OISG" field="shipmentMethodTypeId" name="slaShipmentMethodTypeId"/>
+        <alias entity-alias="OISG" field="contactMechId" name="postalContactMechId"/>
+        <alias entity-alias="OISG" name="telecomContactMechId"/>
         <alias entity-alias="EFO" name="externalFulfillmentOrderItemId"/>
         <alias entity-alias="EFO" name="fulfillmentStatus"/>
         <alias entity-alias="P" field="firstName" name="customerFirstName"/>
@@ -474,10 +370,22 @@ under the License.
         <alias entity-alias="PD" name="productId"/>
         <alias entity-alias="SCENM" field="enumCode" name="salesChannel"/>
         <alias entity-alias="ODR" field="partyId" name="customerPartyId"/>
+        <alias entity-alias="OSH" field="quantity" name="shippedQuantity"/>
+        <alias entity-alias="SHI" name="shipmentId"/>
+        <alias entity-alias="SHI" name="shipmentItemSeqId"/>
+        <alias entity-alias="SHI" field="productId" name="shippedProductId"/>
+        <alias entity-alias="SH" field="statusId" name="shipmentStatusId"/>
+        <alias entity-alias="SH" field="destinationContactMechId" name="shipToContactMechId"/>
+        <alias entity-alias="SH" field="destinationTelecomNumberId" name="shipToTelecomContactMechId"/>
+        <alias entity-alias="SH" name="shipmentMethodTypeId"/>
+        <alias entity-alias="SH" name="shipmentTypeId"/>
+        <alias entity-alias="SHIRS" name="trackingIdNumber"/>
+        <alias entity-alias="SHIRS" name="carrierPartyId"/>
+        <alias entity-alias="PT" name="productTypeId"/>
+        <alias entity-alias="PT" name="isPhysical"/>
         <entity-condition>
             <econditions combine="and">
                 <econdition entity-alias="OH" field-name="orderTypeId" operator="equals" value="SALES_ORDER"/>
-<!--                <econdition entity-alias="OISG" field-name="facilityId" operator="not-equals" value="_NA_"/>-->
                 <econditions combine="or">
                     <econdition entity-alias="EFO" field-name="fulfillmentStatus" operator="equals" value="REJECT"/>
                     <econdition entity-alias="EFO" field-name="fulfillmentStatus" operator="equals" value=""/>

--- a/entity/OmsOrderViewEntities.xml
+++ b/entity/OmsOrderViewEntities.xml
@@ -392,7 +392,7 @@ under the License.
                 <econditions combine="or">
                     <econdition entity-alias="EFO" field-name="fulfillmentStatus" operator="equals" value="REJECT"/>
                     <econdition entity-alias="EFO" field-name="fulfillmentStatus" operator="equals" value=""/>
-                </econditions>.
+                </econditions>
                 <econditions combine="or">
                     <econdition entity-alias="OISGA" field-name="quantity" operator="greater" to-entity-alias="OISGA" to-field-name="cancelQuantity"/>
                     <econdition entity-alias="OISGA" field-name="cancelQuantity" operator="equals" value=""/>

--- a/entity/OmsOrderViewEntities.xml
+++ b/entity/OmsOrderViewEntities.xml
@@ -366,7 +366,7 @@ under the License.
         <alias entity-alias="F" field="externalId" name="facilityExternalId" />
         <alias entity-alias="FT" name="facilityTypeId"/>
         <alias entity-alias="FT" field="parentTypeId" name="parentFacilityTypeId"/>
-        <alias entity-alias="OS" name="statusDatetime"/>
+        <alias entity-alias="OS" name="statusDatetime" function="max"/>
         <alias entity-alias="PD" name="productId"/>
         <alias entity-alias="SCENM" field="enumCode" name="salesChannel"/>
         <alias entity-alias="ODR" field="partyId" name="customerPartyId"/>

--- a/entity/OmsOrderViewEntities.xml
+++ b/entity/OmsOrderViewEntities.xml
@@ -279,7 +279,7 @@ under the License.
 
     <!-- View entity to fetch the Order Items for FulfilledOrder Reporting, using member entities of OFBiz -->
     <view-entity entity-name="OrderItemAndShipmentSyncQueue" package="co.hotwax.warehouse" group="ofbiz_transactional">
-        <description>View to get details for the Fulfilled Order Items.</description>
+        <description>View to get details for the Order Item and Shipment details.</description>
         <member-entity entity-alias="OH" entity-name="org.apache.ofbiz.order.order.OrderHeader"/>
         <member-entity entity-alias="OI" entity-name="org.apache.ofbiz.order.order.OrderItem" join-from-alias="OH">
             <key-map field-name="orderId"/>
@@ -305,6 +305,12 @@ under the License.
             <key-map field-name="shipmentItemSeqId"/>
         </member-entity>
         <member-entity entity-alias="SH" entity-name="org.apache.ofbiz.shipment.shipment.Shipment" join-from-alias="SHI" join-optional="true">
+            <key-map field-name="shipmentId"/>
+        </member-entity>
+        <!-- NOTE: ShipmentRouteSegment entity included for details regarding tracking Number, carrier party and shipment method
+        and be able to group the items using these fields when the view is used in the Fulfilled Items Feed.
+        TODO We may get multiple records for Shipment Route Segments, and this should be revisited for this scenario. -->
+        <member-entity entity-alias="SHIRS" entity-name="org.apache.ofbiz.shipment.shipment.ShipmentRouteSegment" join-from-alias="SH" join-optional="true">
             <key-map field-name="shipmentId"/>
         </member-entity>
         <member-entity entity-alias="EFO" entity-name="co.hotwax.warehouse.ExternalFulfillmentOrderItem" join-from-alias="OISGA" join-optional="true">
@@ -337,9 +343,6 @@ under the License.
         </member-entity>
         <member-entity entity-alias="UOM" entity-name="org.apache.ofbiz.common.uom.Uom" join-from-alias="OH">
             <key-map field-name="currencyUom" related="uomId"/>
-        </member-entity>
-        <member-entity entity-alias="SHIRS" entity-name="org.apache.ofbiz.shipment.shipment.ShipmentRouteSegment" join-from-alias="SH" join-optional="true">
-            <key-map field-name="shipmentId"/>
         </member-entity>
         <alias entity-alias="OH" name="productStoreId"/>
         <alias entity-alias="OH" name="orderId"/>

--- a/entity/OmsOrderViewEntities.xml
+++ b/entity/OmsOrderViewEntities.xml
@@ -376,10 +376,10 @@ under the License.
         <alias entity-alias="SH" field="statusId" name="shipmentStatusId"/>
         <alias entity-alias="SH" field="destinationContactMechId" name="shipToContactMechId"/>
         <alias entity-alias="SH" field="destinationTelecomNumberId" name="shipToTelecomContactMechId"/>
-        <alias entity-alias="SH" name="shipmentMethodTypeId"/>
         <alias entity-alias="SH" name="shipmentTypeId"/>
         <alias entity-alias="SHIRS" name="trackingIdNumber"/>
         <alias entity-alias="SHIRS" name="carrierPartyId"/>
+        <alias entity-alias="SHIRS" name="shipmentMethodTypeId"/>
         <alias entity-alias="PT" name="productTypeId"/>
         <alias entity-alias="PT" name="isPhysical"/>
         <alias entity-alias="PT" name="isDigital"/>

--- a/entity/OmsOrderViewEntities.xml
+++ b/entity/OmsOrderViewEntities.xml
@@ -278,7 +278,7 @@ under the License.
     </view-entity>
 
     <!-- View entity to fetch the Order Items for FulfilledOrder Reporting, using member entities of OFBiz -->
-    <view-entity entity-name="FulfilledOrderItemsSyncQueue" package="co.hotwax.warehouse" group="ofbiz_transactional">
+    <view-entity entity-name="OrderItemAndShipmentSyncQueue" package="co.hotwax.warehouse" group="ofbiz_transactional">
         <description>View to get details for the Fulfilled Order Items.</description>
         <member-entity entity-alias="OH" entity-name="org.apache.ofbiz.order.order.OrderHeader"/>
         <member-entity entity-alias="OI" entity-name="org.apache.ofbiz.order.order.OrderItem" join-from-alias="OH">
@@ -366,14 +366,13 @@ under the License.
         <alias entity-alias="F" field="externalId" name="facilityExternalId" />
         <alias entity-alias="FT" name="facilityTypeId"/>
         <alias entity-alias="FT" field="parentTypeId" name="parentFacilityTypeId"/>
-        <alias entity-alias="OS" name="statusDatetime" />
+        <alias entity-alias="OS" name="statusDatetime"/>
         <alias entity-alias="PD" name="productId"/>
         <alias entity-alias="SCENM" field="enumCode" name="salesChannel"/>
         <alias entity-alias="ODR" field="partyId" name="customerPartyId"/>
         <alias entity-alias="OSH" field="quantity" name="shippedQuantity"/>
         <alias entity-alias="SHI" name="shipmentId"/>
         <alias entity-alias="SHI" name="shipmentItemSeqId"/>
-        <alias entity-alias="SHI" field="productId" name="shippedProductId"/>
         <alias entity-alias="SH" field="statusId" name="shipmentStatusId"/>
         <alias entity-alias="SH" field="destinationContactMechId" name="shipToContactMechId"/>
         <alias entity-alias="SH" field="destinationTelecomNumberId" name="shipToTelecomContactMechId"/>
@@ -383,6 +382,7 @@ under the License.
         <alias entity-alias="SHIRS" name="carrierPartyId"/>
         <alias entity-alias="PT" name="productTypeId"/>
         <alias entity-alias="PT" name="isPhysical"/>
+        <alias entity-alias="PT" name="isDigital"/>
         <entity-condition>
             <econditions combine="and">
                 <econdition entity-alias="OH" field-name="orderTypeId" operator="equals" value="SALES_ORDER"/>

--- a/entity/OmsOrderViewEntities.xml
+++ b/entity/OmsOrderViewEntities.xml
@@ -279,7 +279,7 @@ under the License.
 
     <!-- View entity to fetch the Order Items for FulfilledOrder Reporting, using member entities of OFBiz -->
     <view-entity entity-name="FulfilledOrderItemsSyncQueue" package="co.hotwax.warehouse" group="ofbiz_transactional">
-        <description>View to get details for the Brokered Order Items.</description>
+        <description>View to get details for the Fulfilled Order Items.</description>
         <member-entity entity-alias="OH" entity-name="org.apache.ofbiz.order.order.OrderHeader"/>
         <member-entity entity-alias="OI" entity-name="org.apache.ofbiz.order.order.OrderItem" join-from-alias="OH">
             <key-map field-name="orderId"/>

--- a/entity/OmsOrderViewEntities.xml
+++ b/entity/OmsOrderViewEntities.xml
@@ -375,6 +375,123 @@ under the License.
         </entity-condition>
     </view-entity>
 
+    <!-- View entity to fetch the Order Items for FulfilledOrder Reporting, using member entities of OFBiz -->
+    <view-entity entity-name="FulfilledOrderItemsSyncQueue" package="co.hotwax.warehouse" group="ofbiz_transactional">
+        <description>View to get details for the Brokered Order Items.</description>
+        <member-entity entity-alias="OH" entity-name="org.apache.ofbiz.order.order.OrderHeader"/>
+        <member-entity entity-alias="OI" entity-name="org.apache.ofbiz.order.order.OrderItem" join-from-alias="OH">
+            <key-map field-name="orderId"/>
+        </member-entity>
+        <member-entity entity-alias="SCENM" entity-name="org.apache.ofbiz.common.enum.Enumeration" join-from-alias="OH" join-optional="true">
+            <key-map field-name="salesChannelEnumId" related="enumId"/>
+        </member-entity>
+        <member-entity entity-alias="OISGA" entity-name="org.apache.ofbiz.order.order.OrderItemShipGroupAssoc" join-from-alias="OI">
+            <key-map field-name="orderId"/>
+            <key-map field-name="orderItemSeqId"/>
+<!--            <key-map field-name="shipGroupSeqId"/>-->
+        </member-entity>
+        <member-entity entity-alias="OISG" entity-name="org.apache.ofbiz.order.order.OrderItemShipGroup" join-from-alias="OISGA">
+            <key-map field-name="orderId"/>
+            <key-map field-name="shipGroupSeqId"/>
+        </member-entity>
+<!--        <member-entity entity-alias="OSH" entity-name="org.apache.ofbiz.order.order.OrderShipment" join-from-alias="OISGA" join-optional="true">-->
+<!--            <key-map field-name="orderId"/>-->
+<!--            <key-map field-name="orderItemSeqId"/>-->
+<!--            <key-map field-name="shipGroupSeqId"/>-->
+<!--        </member-entity>-->
+        <member-entity entity-alias="SH" entity-name="org.apache.ofbiz.shipment.shipment.Shipment" join-from-alias="OISG" join-optional="true">
+        <key-map field-name="orderId" related="primaryOrderId"/>
+        <key-map field-name="shipGroupSeqId" related="primaryShipGroupSeqId"/>
+        </member-entity>
+<!--        <member-entity entity-alias="SH" entity-name="org.apache.ofbiz.shipment.shipment.Shipment" join-from-alias="OSH" join-optional="false">-->
+<!--        <key-map field-name="shipmentId"/>-->
+<!--        <key-map field-name="shipGroupSeqId" related="primaryShipGroupSeqId"/>-->
+<!--        </member-entity>-->
+<!--        <member-entity entity-alias="SHI" entity-name="org.apache.ofbiz.shipment.shipment.ShipmentItem" join-from-alias="SH">-->
+<!--            <key-map field-name="shipmentId"/>-->
+<!--        </member-entity>-->
+        <member-entity entity-alias="EFO" entity-name="co.hotwax.warehouse.ExternalFulfillmentOrderItem" join-from-alias="OISGA" join-optional="true">
+            <key-map field-name="orderId"/>
+            <key-map field-name="orderItemSeqId"/>
+            <key-map field-name="shipGroupSeqId"/>
+        </member-entity>
+        <member-entity entity-alias="OS" entity-name="org.apache.ofbiz.order.order.OrderStatus" join-from-alias="OI">
+            <key-map field-name="orderId"/>
+            <key-map field-name="orderItemSeqId"/>
+            <key-map field-name="statusId"/>
+        </member-entity>
+        <member-entity entity-alias="F" entity-name="org.apache.ofbiz.product.facility.Facility" join-from-alias="OISG">
+            <key-map field-name="facilityId"/>
+        </member-entity>
+        <member-entity entity-alias="FT" entity-name="org.apache.ofbiz.product.facility.FacilityType" join-from-alias="F">
+            <key-map field-name="facilityTypeId"/>
+        </member-entity>
+        <member-entity entity-alias="ODR" entity-name="org.apache.ofbiz.order.order.OrderRole" join-from-alias="OH" join-optional="true">
+            <key-map field-name="orderId"/>
+        </member-entity>
+        <member-entity entity-alias="P" entity-name="org.apache.ofbiz.party.party.Person" join-from-alias="ODR" join-optional="true">
+            <key-map field-name="partyId"/>
+        </member-entity>
+        <member-entity entity-alias="PD" entity-name="org.apache.ofbiz.product.product.Product" join-from-alias="OI">
+            <key-map field-name="productId"/>
+        </member-entity>
+        <member-entity entity-alias="UOM" entity-name="org.apache.ofbiz.common.uom.Uom" join-from-alias="OH">
+            <key-map field-name="currencyUom" related="uomId"/>
+        </member-entity>
+        <alias entity-alias="OH" name="productStoreId"/>
+        <alias entity-alias="OH" name="orderId"/>
+<!--        <alias entity-alias="SH" name="primaryOrderId"/>-->
+        <alias entity-alias="OH" name="orderName"/>
+        <alias entity-alias="OH" name="orderDate"/>
+        <alias entity-alias="OH" field="statusId" name="orderStatusId"/>
+        <alias entity-alias="OH" name="entryDate"/>
+        <alias entity-alias="UOM" field="abbreviation" name="currency"/>
+        <alias entity-alias="OH" name="grandTotal"/>
+        <alias entity-alias="OI" name="orderItemSeqId"/>
+        <alias entity-alias="OI" field="statusId" name="itemStatusId"/>
+        <alias entity-alias="OISGA" name="quantity"/>
+<!--        <alias entity-alias="OISGA" field="quantity" name="oiqqqqq"/>-->
+        <alias entity-alias="OI" name="unitPrice"/>
+        <alias entity-alias="PD" name="productTypeId"/>
+        <alias entity-alias="OI" field="externalId" name="orderItemExternalId"/>
+        <alias entity-alias="SH" field="statusId" name="shipmentStatusId"/>
+        <alias entity-alias="SH" field="destinationContactMechId" name="shipToContactMechId"/>
+        <alias entity-alias="SH" field="destinationTelecomNumberId" name="shipToTelecomContactMechId"/>
+        <alias entity-alias="SH" name="shipmentMethodTypeId"/>
+        <alias entity-alias="OISG"  name="shipGroupSeqId"/>
+        <alias entity-alias="SH" name="shipmentId"/>
+<!--        <alias entity-alias="OSH" name="quantity"/>-->
+<!--        <alias entity-alias="OSH" name="shipmentItemSeqId"/>-->
+        <alias entity-alias="EFO" name="externalFulfillmentOrderItemId"/>
+        <alias entity-alias="EFO" name="fulfillmentStatus"/>
+        <alias entity-alias="P" field="firstName" name="customerFirstName"/>
+        <alias entity-alias="P" field="lastName" name="customerLastName"/>
+        <alias entity-alias="F" name="facilityId"/>
+        <alias entity-alias="F" field="externalId" name="facilityExternalId" />
+        <alias entity-alias="FT" name="facilityTypeId"/>
+        <alias entity-alias="FT" field="parentTypeId" name="parentFacilityTypeId"/>
+        <alias entity-alias="OS" name="statusDatetime" />
+        <alias entity-alias="PD" name="productId"/>
+        <alias entity-alias="SCENM" field="enumCode" name="salesChannel"/>
+        <alias entity-alias="ODR" field="partyId" name="customerPartyId"/>
+        <entity-condition>
+            <econditions combine="and">
+                <econdition entity-alias="OH" field-name="orderTypeId" operator="equals" value="SALES_ORDER"/>
+<!--                <econdition entity-alias="OISG" field-name="facilityId" operator="not-equals" value="_NA_"/>-->
+                <econditions combine="or">
+                    <econdition entity-alias="EFO" field-name="fulfillmentStatus" operator="equals" value="REJECT"/>
+                    <econdition entity-alias="EFO" field-name="fulfillmentStatus" operator="equals" value=""/>
+                </econditions>.
+                <econditions combine="or">
+                    <econdition entity-alias="OISGA" field-name="quantity" operator="greater" to-entity-alias="OISGA" to-field-name="cancelQuantity"/>
+                    <econdition entity-alias="OISGA" field-name="cancelQuantity" operator="equals" value=""/>
+                </econditions>
+                <econdition entity-alias="ODR" field-name="roleTypeId" operator="equals" value="BILL_TO_CUSTOMER"/>
+            </econditions>
+            <order-by field-name="entryDate"/>
+        </entity-condition>
+    </view-entity>
+
     <view-entity entity-name="PostalAddressView" package="co.hotwax.financial" group="ofbiz_transactional">
         <member-entity entity-alias="PA" entity-name="org.apache.ofbiz.party.contact.PostalAddress"/>
         <member-entity entity-alias="COUNTRYGEO" entity-name="org.apache.ofbiz.common.geo.Geo" join-from-alias="PA" join-optional="true">


### PR DESCRIPTION
Closes #1 

1. Added the ShipmentOrderItemsSyncQueue View for shipment order Items.
2. New view to fetch Fulfilled Order Items, for this we should include data model for Shipment Item and related entities.
3. The view could contain items which are packed etc, based on the Shipment Status, the view will be used to prepare the Fulfilled Order Items Feed, as the status will be 'SHIPMENT_SHIPPED' for such records.