### PR TITLE
Improved: Extended ServiceJob entity to include parentJobName field (#3)

### DIFF
--- a/data/UpgradeData_Upcoming.xml
+++ b/data/UpgradeData_Upcoming.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<entity-facade-xml type="ext-upgrade-dev">
+
+    <!-- Enumeration Type data for Service Job Types -->
+    <moqui.basic.EnumerationType description="Service Job Type" enumTypeId="ServiceJobType"/>
+</entity-facade-xml>

--- a/entity/OmsServiceEntities.xml
+++ b/entity/OmsServiceEntities.xml
@@ -28,6 +28,12 @@ under the License.
     <!-- Extending the entity to include a field to store reference of parent job name in the cloned service job -->
     <extend-entity entity-name="ServiceJob" package="moqui.service.job">
         <field  name="parentJobName" type="text-short"/>
+        <field name="jobTypeEnumId" type="id"/>
+        <relationship type="one" title="ServiceJobType" related="moqui.basic.Enumeration">
+            <key-map field-name="jobTypeEnumId"/></relationship>
+        <seed-data>
+            <moqui.basic.EnumerationType description="Service Job Type" enumTypeId="ServiceJobType"/>
+        </seed-data>
     </extend-entity>
 </entities>
 

--- a/entity/OmsServiceEntities.xml
+++ b/entity/OmsServiceEntities.xml
@@ -29,7 +29,7 @@ under the License.
     <extend-entity entity-name="ServiceJob" package="moqui.service.job">
         <field name="parentJobName" type="text-short"/>
         <field name="jobTypeEnumId" type="id"/>
-        <relationship type="one" title="ServiceJobType" related="moqui.basic.Enumeration">
+        <relationship type="one-nofk" title="ServiceJobType" related="moqui.basic.Enumeration">
             <key-map field-name="jobTypeEnumId"/></relationship>
         <seed-data>
             <moqui.basic.EnumerationType description="Service Job Type" enumTypeId="ServiceJobType"/>

--- a/entity/OmsServiceEntities.xml
+++ b/entity/OmsServiceEntities.xml
@@ -24,5 +24,10 @@ under the License.
     <extend-entity entity-name="SystemMessage" package="moqui.service.message">
         <field name="productStoreId" type="id"/>
     </extend-entity>
+
+    <!-- Extending the entity to include a field to store reference of parent job name in the cloned service job -->
+    <extend-entity entity-name="ServiceJob" package="moqui.service.job">
+        <field  name="parentJobName" type="text-short"/>
+    </extend-entity>
 </entities>
 

--- a/entity/OmsServiceEntities.xml
+++ b/entity/OmsServiceEntities.xml
@@ -27,7 +27,7 @@ under the License.
 
     <!-- Extending the entity to include a field to store reference of parent job name in the cloned service job -->
     <extend-entity entity-name="ServiceJob" package="moqui.service.job">
-        <field  name="parentJobName" type="text-short"/>
+        <field name="parentJobName" type="text-short"/>
         <field name="jobTypeEnumId" type="id"/>
         <relationship type="one" title="ServiceJobType" related="moqui.basic.Enumeration">
             <key-map field-name="jobTypeEnumId"/></relationship>


### PR DESCRIPTION
Closes #3 

1. Extended ServiceJob entity to include parentJobName field so that it can be referenced in the cloned Service Job