### PR TITLE
Added: View for Product Catalog and Category Members (#16)

### DIFF
--- a/entity/OmsProductViewEntities.xml
+++ b/entity/OmsProductViewEntities.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<entities xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:noNamespaceSchemaLocation="http://moqui.org/xsd/entity-definition-3.xsd">
+
+    <view-entity entity-name="ProductStoreCatalogAndCategoryMembers" package="co.hotwax.shopify" group="ofbiz_transactional">
+        <description>View entity for the product categories</description>
+        <member-entity entity-alias="PSC" entity-name="org.apache.ofbiz.product.store.ProductStoreCatalog"/>
+        <member-entity entity-alias="PCC" entity-name="org.apache.ofbiz.product.catalog.ProdCatalogCategory" join-from-alias="PSC">
+            <key-map field-name="prodCatalogId"/>
+        </member-entity>
+        <member-entity entity-alias="PCM" entity-name="org.apache.ofbiz.product.category.ProductCategoryMember" join-from-alias="PCC">
+            <key-map field-name="productCategoryId"/>
+        </member-entity>
+
+        <alias entity-alias="PCC" name="productCategoryId"/>
+        <alias entity-alias="PCC" name="prodCatalogCategoryTypeId"/>
+        <alias entity-alias="PCM" name="productId"/>
+        <alias entity-alias="PCM" name="productCategoryMemberFromDate" field="fromDate"/>
+        <alias entity-alias="PCM" name="productCategoryMemberThruDate" field="thruDate"/>
+        <alias entity-alias="PSC" name="productStoreId"/>
+    </view-entity>
+</entities>

--- a/entity/OmsProductViewEntities.xml
+++ b/entity/OmsProductViewEntities.xml
@@ -21,8 +21,8 @@ under the License.
 <entities xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:noNamespaceSchemaLocation="http://moqui.org/xsd/entity-definition-3.xsd">
 
-    <view-entity entity-name="ProductStoreCatalogAndCategoryMembers" package="co.hotwax.shopify" group="ofbiz_transactional">
-        <description>View entity for the product categories</description>
+    <view-entity entity-name="ProductStoreCatalogAndCategoryMembers" package="co.hotwax.product.catalog.category" group="ofbiz_transactional">
+        <description>View entity for Product Store Catalog and Category Members.</description>
         <member-entity entity-alias="PSC" entity-name="org.apache.ofbiz.product.store.ProductStoreCatalog"/>
         <member-entity entity-alias="PCC" entity-name="org.apache.ofbiz.product.catalog.ProdCatalogCategory" join-from-alias="PSC">
             <key-map field-name="prodCatalogId"/>
@@ -30,12 +30,15 @@ under the License.
         <member-entity entity-alias="PCM" entity-name="org.apache.ofbiz.product.category.ProductCategoryMember" join-from-alias="PCC">
             <key-map field-name="productCategoryId"/>
         </member-entity>
-
+        <alias entity-alias="PSC" name="productStoreId"/>
+        <alias entity-alias="PSC" field="fromDate" name="fromDatePSC"/>
+        <alias entity-alias="PSC" field="thruDate" name="thruDatePSC"/>
         <alias entity-alias="PCC" name="productCategoryId"/>
         <alias entity-alias="PCC" name="prodCatalogCategoryTypeId"/>
+        <alias entity-alias="PCC" field="fromDate" name="fromDatePCC"/>
+        <alias entity-alias="PCC" field="thruDate" name="thruDatePCC"/>
         <alias entity-alias="PCM" name="productId"/>
-        <alias entity-alias="PCM" name="productCategoryMemberFromDate" field="fromDate"/>
-        <alias entity-alias="PCM" name="productCategoryMemberThruDate" field="thruDate"/>
-        <alias entity-alias="PSC" name="productStoreId"/>
+        <alias entity-alias="PCM" field="fromDate" name="fromDatePCM"/>
+        <alias entity-alias="PCM" field="thruDate" name="thruDatePCM"/>
     </view-entity>
 </entities>

--- a/entity/OmsProductViewEntities.xml
+++ b/entity/OmsProductViewEntities.xml
@@ -21,7 +21,7 @@ under the License.
 <entities xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:noNamespaceSchemaLocation="http://moqui.org/xsd/entity-definition-3.xsd">
 
-    <view-entity entity-name="ProductStoreCatalogAndCategoryMembers" package="co.hotwax.product.catalog.category" group="ofbiz_transactional">
+    <view-entity entity-name="ProductStoreCatalogAndCategoryMember" package="co.hotwax.product.catalog.category" group="ofbiz_transactional">
         <description>View entity for Product Store Catalog and Category Members.</description>
         <member-entity entity-alias="PSC" entity-name="org.apache.ofbiz.product.store.ProductStoreCatalog"/>
         <member-entity entity-alias="PCC" entity-name="org.apache.ofbiz.product.catalog.ProdCatalogCategory" join-from-alias="PSC">

--- a/entity/OmsProductViewEntities.xml
+++ b/entity/OmsProductViewEntities.xml
@@ -31,14 +31,14 @@ under the License.
             <key-map field-name="productCategoryId"/>
         </member-entity>
         <alias entity-alias="PSC" name="productStoreId"/>
-        <alias entity-alias="PSC" field="fromDate" name="fromDatePSC"/>
-        <alias entity-alias="PSC" field="thruDate" name="thruDatePSC"/>
+        <alias entity-alias="PSC" field="fromDate" name="pscFromDate"/>
+        <alias entity-alias="PSC" field="thruDate" name="pscThruDate"/>
         <alias entity-alias="PCC" name="productCategoryId"/>
         <alias entity-alias="PCC" name="prodCatalogCategoryTypeId"/>
-        <alias entity-alias="PCC" field="fromDate" name="fromDatePCC"/>
-        <alias entity-alias="PCC" field="thruDate" name="thruDatePCC"/>
+        <alias entity-alias="PCC" field="fromDate" name="pccFromDate"/>
+        <alias entity-alias="PCC" field="thruDate" name="pccThruDate"/>
         <alias entity-alias="PCM" name="productId"/>
-        <alias entity-alias="PCM" field="fromDate" name="fromDatePCM"/>
-        <alias entity-alias="PCM" field="thruDate" name="thruDatePCM"/>
+        <alias entity-alias="PCM" field="fromDate" name="pcmFromDate"/>
+        <alias entity-alias="PCM" field="thruDate" name="pcmThruDate"/>
     </view-entity>
 </entities>


### PR DESCRIPTION
closes #16 

1. Added view ProductStoreCatalogAndCategoryMembers to identify the product categories for a product.
2. Included the following entities in the view:
    1. ProductStoreCatalog
    2. ProdCatalogCategory
    3. ProductCategoryMember 
3. The view has the following fields:
    1. productCategoryId
    2. prodCatalogCategoryTypeId
    3. productId
    4. productCategoryMemberFromDate
    5. productCategoryMemberThruDate
    6. productStoreId
    
    
