### PR TITLE
Added: New entity for Order Adjustment History for fulfilled Order Items (#35)

### DIFF
--- a/entity/HwmappsEntitymodel.xml
+++ b/entity/HwmappsEntitymodel.xml
@@ -2860,6 +2860,18 @@ under the License.
         </relationship>
     </entity>
 
+    <entity entity-name="FulfilledOrderAdjustmentHistory" package="co.hotwax.common" group="ofbiz_transactional">
+        <field name="orderAdjustmentHistoryId" type="id" is-pk="true"/>
+        <field name="orderAdjustmentId" type="id"/>
+        <field name="orderAdjustmentTypeId" type="id"/>
+        <field name="orderId" type="id"/>
+        <field name="createdDate" type="date-time"/>
+        <field name="comments" type="text-very-long"/>
+        <relationship type="one" related="org.apache.ofbiz.order.order.OrderAdjustment">
+            <key-map field-name="orderAdjustmentId"/>
+        </relationship>
+    </entity>
+
     <entity entity-name="ShipmentItemHistory" package="co.hotwax.common" group="ofbiz_transactional">
         <field name="shipmentItemHistoryId" type="id" is-pk="true"/>
         <field name="shipmentId" type="id"/>

--- a/entity/OmsOrderViewEntities.xml
+++ b/entity/OmsOrderViewEntities.xml
@@ -464,6 +464,24 @@ under the License.
             <econdition entity-alias="OAH" field-name="orderAdjustmentId" value=""/>
         </entity-condition>
     </view-entity>
+    <view-entity entity-name="FulfilledOrderAdjustmentAndHistory" package="co.hotwax.financial" group="ofbiz_transactional">
+        <member-entity entity-alias="OA" entity-name="org.apache.ofbiz.order.order.OrderAdjustment"/>
+        <member-entity entity-alias="FOAH" entity-name="co.hotwax.common.FulfilledOrderAdjustmentHistory" join-from-alias="OA" join-optional="true">
+            <key-map field-name="orderAdjustmentId"/>
+        </member-entity>
+        <alias entity-alias="OA" name="orderAdjustmentId"/>
+        <alias entity-alias="OA" name="orderAdjustmentTypeId"/>
+        <alias entity-alias="OA" name="orderId"/>
+        <alias entity-alias="OA" name="orderItemSeqId"/>
+        <alias entity-alias="OA" name="shipGroupSeqId"/>
+        <alias entity-alias="OA" name="comments"/>
+        <alias entity-alias="OA" name="description"/>
+        <alias entity-alias="OA" name="amount"/>
+        <alias entity-alias="OA" name="createdDate"/>
+        <entity-condition>
+            <econdition entity-alias="FOAH" field-name="orderAdjustmentId" value=""/>
+        </entity-condition>
+    </view-entity>
     <view-entity entity-name="ReturnItemAndAdjustment" package="co.hotwax.financial" group="ofbiz_transactional">
         <description>View to get the Return Items and their Adjustments.</description>
         <member-entity entity-alias="RI" entity-name="org.apache.ofbiz.order.return.ReturnItem"/>


### PR DESCRIPTION
closes #35 
The OrderAdjustmentHistory entity already exists, and is being used for maintaining the history of the adjustments sent as part of the Brokered Order Items Feed, so added a separate entity for the adjustments sent as part of fulfilled items.
Added the FulfilledOrderAdjustmentAndHistory view for fetching the eligible order level adjustment.