### PR TITLE
Added: Reserved Date time field in BrokeredOrderItemsSyncQueue view (#38)

### DIFF
--- a/entity/OmsOrderViewEntities.xml
+++ b/entity/OmsOrderViewEntities.xml
@@ -241,6 +241,7 @@ under the License.
         <alias entity-alias="OI" name="orderItemSeqId"/>
         <alias entity-alias="OI" field="statusId" name="itemStatusId"/>
         <alias entity-alias="OISGINR" name="quantity" function="sum"/>
+        <alias entity-alias="OISGINR" name="reservedDatetime"/>
         <alias entity-alias="OI" name="unitPrice"/>
         <alias entity-alias="OI" field="externalId" name="orderItemExternalId"/>
         <alias entity-alias="OISG" name="shipGroupSeqId"/>
@@ -252,10 +253,10 @@ under the License.
         <alias entity-alias="P" field="firstName" name="customerFirstName"/>
         <alias entity-alias="P" field="lastName" name="customerLastName"/>
         <alias entity-alias="F" name="facilityId"/>
-        <alias entity-alias="F" field="externalId" name="facilityExternalId" />
+        <alias entity-alias="F" field="externalId" name="facilityExternalId"/>
         <alias entity-alias="FT" name="facilityTypeId"/>
         <alias entity-alias="FT" field="parentTypeId" name="parentFacilityTypeId"/>
-        <alias entity-alias="OS" name="statusDatetime" />
+        <alias entity-alias="OS" name="statusDatetime"/>
         <alias entity-alias="PD" name="productId"/>
         <alias entity-alias="PD" name="productTypeId"/>
         <alias entity-alias="SCENM" field="enumCode" name="salesChannel"/>


### PR DESCRIPTION
closes #38 
Added the reservedDatetime field in Brokered Order Item Sync Queue view for fetching the reserved Date time for brokered order items feed.