### PR TITLE
Improved: ShipmentAndItemAndReceipt view to add the serialNumber (#44)

### DIFF
--- a/entity/OmsShipmentViewEntities.xml
+++ b/entity/OmsShipmentViewEntities.xml
@@ -58,6 +58,7 @@ under the License.
         <alias entity-alias="SITM" name="productId"/>
         <alias entity-alias="SITM" name="quantity"/>
         <alias entity-alias="SITM" name="availableToPromise"/>
+        <alias entity-alias="SITM" name="serialNumber"/>
         <alias entity-alias="SR" name="totalQuantityAccepted" field="quantityAccepted" function="sum"/>
         <alias entity-alias="SR" name="receivedDate" field="datetimeReceived" function="max"/>
         <alias entity-alias="SR" name="receiptId"/>


### PR DESCRIPTION
closes - #44 

As discussed we will use the existing view `ShipmentAndItemAndReceipt` to fetch the eligible orders.

We only need to add the serialNumber field in the existing view.