### PR TITLE
Improved: Included externalId in ShipmentAndItemAndReceipt view entity

### DIFF
--- a/entity/HwmappsEntitymodel.xml
+++ b/entity/HwmappsEntitymodel.xml
@@ -1967,6 +1967,7 @@ under the License.
         </field>
             <field name="availableToPromise" type="number-decimal">
         </field>
+        <field name="externalId" type="id-long"/>
     </extend-entity>
     <extend-entity entity-name="PicklistItem" package="org.apache.ofbiz.shipment.picklist" group="ofbiz_transactional">
             <field name="picked" type="number-decimal">

--- a/entity/OmsShipmentViewEntities.xml
+++ b/entity/OmsShipmentViewEntities.xml
@@ -59,6 +59,7 @@ under the License.
         <alias entity-alias="SITM" name="quantity"/>
         <alias entity-alias="SITM" name="availableToPromise"/>
         <alias entity-alias="SITM" name="serialNumber"/>
+        <alias entity-alias="SITM" field="externalId" name="shipmentItemExternalId"/>
         <alias entity-alias="SR" name="totalQuantityAccepted" field="quantityAccepted" function="sum"/>
         <alias entity-alias="SR" name="receivedDate" field="datetimeReceived" function="max"/>
         <alias entity-alias="SR" name="receiptId"/>


### PR DESCRIPTION
closes- #44

Discussed  we will use externalId to prepare the line_id for Transfer Order Shipments Feed instead of serialNumber.

Since the serialNumber field is used for serialized inventory shipment.

1. **NOTE:**  We need to add the field external Id in the ShipmentItem entity, since in the ofbiz entity data model we have extended the field externalId in the ShipmentItem entity.
2. Added the externalId as shipmentItemExternalId in the ShipmentAndItemAndReceipt view.

