### PR TITLE
Support of return Channel Enum Id in FinancialReturnItemsSyncQueue view

### DIFF
--- a/entity/DatamodelOrderEntitymodel.xml
+++ b/entity/DatamodelOrderEntitymodel.xml
@@ -2586,6 +2586,8 @@ under the License.
         </field>
             <field name="supplierRmaId" type="id">
         </field>
+        <field name="returnChannelEnumId" type="id">
+        </field>
         <relationship type="one" fk-name="RTN_HEAD_TYPE" related="org.apache.ofbiz.order.return.ReturnHeaderType">
             <key-map field-name="returnHeaderTypeId"/>
         </relationship>

--- a/entity/OmsFinancialViewEntities.xml
+++ b/entity/OmsFinancialViewEntities.xml
@@ -46,6 +46,7 @@ under the License.
         <alias entity-alias="RI" name="returnItemSeqId"/>
         <alias entity-alias="RH" name="entryDate"/>
         <alias entity-alias="RH" name="returnDate"/>
+        <alias entity-alias="RH" name="returnChannelEnumId"/>
         <alias entity-alias="RI" name="orderId"/>
         <alias entity-alias="RI" name="orderItemSeqId" />
         <alias entity-alias="RI" name="returnItemAmountTotal" field="returnPrice"/>


### PR DESCRIPTION
close https://github.com/hotwax/ofbiz-mantle-udm/issues/55

1. Added the Support of return Channel Enum Id in Returns Financial Feed to fetch all returns completed from any specific Channels and it can be warehouse or happy returns, In-Store etc.
2. Added the return Channel Enum Id in FinancialReturnItemsSyncQueue view.
3. Added the return Channel Enum Id in the ReturnHeader entity.

