### PR TITLE
Used shipmentId of shipmentItemHistory to filter records for ShipmentAndItemAndReceipt view entity

### DIFF
--- a/entity/OmsShipmentViewEntities.xml
+++ b/entity/OmsShipmentViewEntities.xml
@@ -64,7 +64,7 @@ under the License.
         <alias entity-alias="SR" name="receivedDate" field="datetimeReceived" function="max"/>
         <alias entity-alias="SR" name="receiptId"/>
         <entity-condition>
-            <econdition entity-alias="SIH" field-name="receiptId" operator="equals" value=""/>
+            <econdition entity-alias="SIH" field-name="shipmentId" operator="equals" value=""/>
         </entity-condition>
     </view-entity>
 


### PR DESCRIPTION
Closes - https://github.com/hotwax/ofbiz-mantle-udm/issues/70


1. Earlier, In the ShipmentAndItemAndReceipt view entity, we have added the null check on the receipt ID of the ShipmentItemHistory which means get all the shipment items where the receipt ID does not exist in the shipmentItemHistory.
2. As per the issue - [1](https://git.hotwax.co/HC2/plugins/ofbiz-oms-mantle/-/issues/494) In the ShipmentAndItemAndReceipt view, we will add the check on the shipment ID of ShipmentItemHistory instead of the receipt ID. 