### PR TITLE
ShipmentItemHistory joined with ShipmentItem instead of ShipmentReceipt in the ShipmentAndItemAndReceipt (#75)

### DIFF
--- a/entity/OmsShipmentViewEntities.xml
+++ b/entity/OmsShipmentViewEntities.xml
@@ -31,8 +31,9 @@ under the License.
             <key-map field-name="shipmentId"/>
             <key-map field-name="shipmentItemSeqId"/>
         </member-entity>
-        <member-entity entity-alias="SIH" entity-name="co.hotwax.common.ShipmentItemHistory" join-from-alias="SR" join-optional="true">
-            <key-map field-name="receiptId"/>
+        <member-entity entity-alias="SIH" entity-name="co.hotwax.common.ShipmentItemHistory" join-from-alias="SITM" join-optional="true">
+            <key-map field-name="shipmentId"/>
+            <key-map field-name="shipmentItemSeqId"/>
         </member-entity>
         <member-entity entity-alias="OH" entity-name="org.apache.ofbiz.order.order.OrderHeader" join-from-alias="SH" join-optional="true">
             <key-map field-name="primaryOrderId" related="orderId"/>


### PR DESCRIPTION
1. The ShipmentItemHistory should be joined with ShipmentItem instead of ShipmentReceipt as now we create history for all items irrespective of the receipt.
2. The assumption is that a shipment item can be received only once, so we should create history for all items in the shipment.