### PR TITLE
Cherry Pick change for Added the quantity field in the Brokered Items view

### DIFF
--- a/entity/OmsOrderViewEntities.xml
+++ b/entity/OmsOrderViewEntities.xml
@@ -246,7 +246,8 @@ under the License.
         <alias entity-alias="OH" name="grandTotal"/>
         <alias entity-alias="OI" name="orderItemSeqId"/>
         <alias entity-alias="OI" field="statusId" name="itemStatusId"/>
-        <alias entity-alias="OISGINR" name="quantity" function="sum"/>
+        <alias entity-alias="OI" field="quantity" name="orderItemQuantity"/>
+        <alias entity-alias="OISGINR" field="quantity" name="reservedItemQuantity" function="sum"/>
         <alias entity-alias="OISGINR" name="reservedDatetime"/>
         <alias entity-alias="OI" name="unitPrice"/>
         <alias entity-alias="OI" field="externalId" name="orderItemExternalId"/>


### PR DESCRIPTION
Added the quantity field of the OrderItem entity in the BrokeredOrderItemsSyncQueue, to distinguish the quantity fields of OrderItem and OrderItemShipGrpInvRes entities, we have changed the names as orderItemQuantity and reservedItemQuantity respectively, we just have to fetch quantity field's value from OrderItem as it is, hence didn't added any aggregate function. (#83)