### PR TITLE
Improved: Removed the shipGroupSeqId from OrderItemAssocAndShipment View (#85)

### DIFF
--- a/entity/OmsOrderViewEntities.xml
+++ b/entity/OmsOrderViewEntities.xml
@@ -699,7 +699,6 @@ under the License.
         <member-entity entity-alias="OS" entity-name="org.apache.ofbiz.order.order.OrderShipment" join-from-alias="OIA">
             <key-map field-name="toOrderId" related="orderId"/>
             <key-map field-name="toOrderItemSeqId" related="orderItemSeqId"/>
-            <key-map field-name="toShipGroupSeqId" related="shipGroupSeqId"/>
         </member-entity>
         <member-entity entity-alias="SH" entity-name="org.apache.ofbiz.shipment.shipment.Shipment" join-from-alias="OS">
             <key-map field-name="shipmentId"/>


### PR DESCRIPTION
Closes #85
1. Removed the shipGroupSeqId in OrderItemAssocAndShipment view.